### PR TITLE
Step-by-step updates to interview-test

### DIFF
--- a/index.css
+++ b/index.css
@@ -162,6 +162,12 @@ body {
 .brick {
     padding: 20px;
 }
+.brick.double {
+    grid-column: span 2;
+}
+.brick.triple {
+    grid-column: span 3;
+}
 .title {
     text-align: center;
     font-size: 20px;
@@ -177,14 +183,14 @@ body {
     line-height: 24px;
     margin: 12px 0;
 }
-
 .masonry {
-    margin: 0 auto;
-    padding: 50px;
+    display: grid;
     gap: var(--spacing-m);
+    grid-template-columns: 1fr 1fr 1fr;
+    margin: 0 auto;
     max-width: 1000px;
+    padding: 50px;
 }
-
 .faq {
     max-width: 1000px;
     margin: 20px auto;

--- a/index.css
+++ b/index.css
@@ -265,3 +265,42 @@ body {
         flex-direction: row;
     }
 }
+@media screen and (min-width: 426px) and (max-width: 769px) {
+    .brick.double {
+        grid-column: auto;
+    }
+    .brick.triple {
+        grid-column: auto;
+    }
+    .masonry {
+        grid-template-columns: auto;
+    }
+}
+@media screen and (max-width: 426px) {
+    .brick.double {
+        grid-column: auto;
+    }
+    .brick.triple {
+        grid-column: auto;
+    }
+    .con-button {
+        margin-bottom: 25px;
+        margin-left: -25px;
+        width: 100%;
+    }
+    .hero {
+        padding: 40px;
+    }
+    .masonry {
+        grid-template-columns: auto;
+        padding: 30px;
+    }
+    .section:last-child {
+        margin-bottom: 125px;
+    }
+    .banner .con-button {
+        margin-bottom: 0px;
+        margin-left: -32px;
+        width: 75%;
+    }
+}

--- a/index.css
+++ b/index.css
@@ -236,8 +236,13 @@ body {
 }
 .banner {
     background-color: #eee;
+    bottom: -100%; /* Start off-screen */
     padding: 16px;
+    position: fixed;
     text-align: center;
+    transition: bottom 0.5s ease; /* Smooth transition for the bottom property */
+    width: 100%;
+    z-index: 1000; /* Ensure it's above other content */
 }
 .banner .con-button.blue {
     margin-left: 8px;

--- a/index.css
+++ b/index.css
@@ -2,36 +2,40 @@
     --global-height-nav: 64px;
     --global-height-breadcrumbs: 33px;
     --global-height-navPromo: 65px;
-    --feds-totalheight-nav: calc(var(--feds-height-nav, --global-height-nav) + var(--feds-height-breadcrumbs, --global-height-breadcrumbs));
+    --feds-totalheight-nav: calc(
+        var(--feds-height-nav, --global-height-nav) +
+            var(--feds-height-breadcrumbs, --global-height-breadcrumbs)
+    );
     --link-color: #035fe6;
     --link-hover-color: #136ff6;
-    --link-color-dark: #1473E6;
+    --link-color-dark: #1473e6;
     --link-hover-color-dark: #0d66d0;
     --background-color: #fff;
     --overlay-background-color: #ffffff20;
     --highlight-background-color: #ffffff40;
     --text-color: #2c2c2c;
-    --color-white: #FFF;
-    --color-gray-100: #F8F8F8;
-    --color-gray-200: #E8E8E8;
-    --color-gray-300: #D4D4D4;
-    --color-gray-400: #B6B6B6;
+    --color-white: #fff;
+    --color-gray-100: #f8f8f8;
+    --color-gray-200: #e8e8e8;
+    --color-gray-300: #d4d4d4;
+    --color-gray-400: #b6b6b6;
     --color-gray-500: #909090;
     --color-gray-600: #686868;
     --color-gray-700: #444;
     --color-gray-800: #242424;
     --color-black: #000;
-    --color-brand-title: #000B1D;
+    --color-brand-title: #000b1d;
     --color-accent: var(--link-color-dark);
     --color-accent-hover: var(--link-hover-color-dark);
     --color-accent-down: #095aba;
     --color-accent-focus-ring: #378ef0;
-    --color-info-accent: #5C5CE0;
-    --color-info-accent-hover: #4646C6;
-    --color-info-accent-down: #3D3DB4;
-    --color-info-accent-light: #DEDEF9;
-    --body-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
-    --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
+    --color-info-accent: #5c5ce0;
+    --color-info-accent-hover: #4646c6;
+    --color-info-accent-down: #3d3db4;
+    --color-info-accent-light: #dedef9;
+    --body-font-family: "Adobe Clean", adobe-clean, "Trebuchet MS", sans-serif;
+    --fixed-font-family: "Roboto Mono", menlo, consolas, "Liberation Mono",
+        monospace;
     --spacing-xxs: 8px;
     --spacing-xs: 16px;
     --spacing-s: 24px;
@@ -88,7 +92,9 @@
     --grid-container-width: 83.4%;
     --grid-column-width: calc(var(--grid-container-width) / 12);
     --grid-margins-width: calc((100vw - var(--grid-container-width)) / 2);
-    --grid-margins-width-10: calc((100vw - (var(--grid-column-width) * 10)) / 2);
+    --grid-margins-width-10: calc(
+        (100vw - (var(--grid-column-width) * 10)) / 2
+    );
     --grid-margins-width-8: calc((100vw - (var(--grid-column-width) * 8)) / 2);
     --grid-margins-width-6: calc((100vw - (var(--grid-column-width) * 6)) / 2);
     --aspect-ratio-square: 1/1;
@@ -184,6 +190,9 @@ body {
     margin: 20px auto;
     border-bottom: 1px solid #ccc;
 }
+.faq .faq-set {
+    cursor: pointer;
+}
 .faq .question {
     border-top: 1px solid #ccc;
     padding: 8px;
@@ -193,20 +202,34 @@ body {
     position: relative;
 }
 .faq .answer {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
     padding: 0 8px;
+    transition: opacity 0.5s, max-height 0.5s; /* Smooth transition for opacity and max-height */
+}
+.faq .answer.open {
+    max-height: 500px; /* Set to a max-height that accommodates content */
+    opacity: 1;
 }
 .faq .question::after {
-    content: '';
-    display: block;
-    box-sizing: border-box;
-    position: absolute;
-    width: 12px;
-    height: 11px;
-    border-top: 2px solid;
     border-right: 2px solid;
-    transform: rotate(225deg);
+    border-top: 2px solid;
+    box-sizing: border-box;
+    content: "";
+    display: block;
+    height: 12px;
+    position: absolute;
     right: 12px;
     top: 36px;
+    transform: rotate(225deg);
+    transition: transform 0.3s ease; /* Add transition for smooth rotation */
+    width: 12px;
+}
+.faq .question.rotated::after {
+    transform: rotate(
+        135deg
+    ); /* Rotate 90 degrees from the original position */
 }
 .faq .answer p {
     margin-top: 0;
@@ -224,7 +247,6 @@ body {
 .section:last-child {
     margin-bottom: 100px;
 }
-
 
 @media screen and (min-width: 600px) {
     .action-area {

--- a/index.js
+++ b/index.js
@@ -164,7 +164,33 @@ function processFaq(el) {
 
 function processBanner(el) {
     // add code here
+    processLinks(el, "b");
+
+    // Find the "banner" div and initially hide it or ensure it's not fixed
+    const bannerDiv = document.querySelector(".banner");
+    // Initially set the banner to be at the bottom of the view
+    bannerDiv.style.bottom = "-100%"; // Ensure it starts off-screen
+
+    // Function to check the visibility of the "hero" div
+    function checkHeroVisibility() {
+        const heroDiv = document.querySelector(".hero");
+        const heroBottom = heroDiv.getBoundingClientRect().bottom;
+
+        if (heroBottom < 0) {
+            // "hero" is completely off the screen
+            bannerDiv.style.bottom = "0"; // Bring it up
+        } else {
+            bannerDiv.style.bottom = "-100%"; // Hide it
+        }
+    }
+
+    // Listen for scroll events to check the "hero" div visibility
+    window.addEventListener("scroll", checkHeroVisibility);
+
+    // Initial check in case the page is loaded with the "hero" div already off the screen
+    checkHeroVisibility();
 }
+
 document.querySelectorAll(".hero").forEach(processHero);
 document.querySelectorAll(".brick").forEach(processBrick);
 document.querySelectorAll(".faq").forEach(processFaq);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,21 @@ const FAQ = [
 ];
 
 // add code here if needed
+function addViewportMeta() {
+    // Create a new meta element
+    const meta = document.createElement("meta");
+
+    // Set the name and content attributes
+    meta.setAttribute("name", "viewport");
+    meta.setAttribute(
+        "content",
+        "width=device-width, initial-scale=1, minimum-scale=1"
+    );
+
+    // Append the meta element to the head
+    document.getElementsByTagName("head")[0].appendChild(meta);
+}
+
 function processLinks(parentDiv, parentTag, additionalClass = "") {
     // Find all 'a' tags that are children of the specified parent tags
     const allAsInsideParent = parentDiv.querySelectorAll(`${parentTag} > a`);
@@ -191,6 +206,7 @@ function processBanner(el) {
     checkHeroVisibility();
 }
 
+addViewportMeta();
 document.querySelectorAll(".hero").forEach(processHero);
 document.querySelectorAll(".brick").forEach(processBrick);
 document.querySelectorAll(".faq").forEach(processFaq);

--- a/index.js
+++ b/index.js
@@ -84,7 +84,23 @@ function processHero(el) {
 function processBrick(el) {
     processBackgroundColor(el);
     // add code here
+    // Define parent 'div'
+    const parentDiv = el;
+
+    // Find all 'p' tags in the parent 'div'
+    const allPs = parentDiv.querySelectorAll("p");
+
+    // Ensure there are enough paragraphs to avoid errors
+    if (allPs.length >= 3) {
+        // Add the class "title" to the first paragraph
+        allPs[0].classList.add("title");
+        // Add the class "price" to the second paragraph
+        allPs[1].classList.add("price");
+        // Add the class "description" to the third paragraph
+        allPs[2].classList.add("description");
+    }
 }
+
 function processFaq(el) {
     // improve this code
     el.innerHTML = `

--- a/index.js
+++ b/index.js
@@ -1,23 +1,41 @@
 const FAQ = [
     {
         q: "How much does Photoshop cost?",
-        a: "Plans start at US$22.99/mo."
+        a: "Plans start at US$22.99/mo.",
     },
     {
         q: "Can you use Photoshop to edit videos?",
-        a: "Yes, you can use Photoshop to edit videos."
+        a: "Yes, you can use Photoshop to edit videos.",
     },
     {
         q: "Is Photoshop available without a subscription?",
-        a: "Photoshop is only available as part of a Creative Cloud plan, which includes the latest features, updates, fonts, and more."
-    }
+        a: "Photoshop is only available as part of a Creative Cloud plan, which includes the latest features, updates, fonts, and more.",
+    },
 ];
 
 // add code here if needed
 
 function processBackgroundColor(el) {
     // add code here
+    // Define parent 'div'
+    const parentDiv = el;
+
+    // Find the 'p' tag containing the color code
+    const colorCodeP = parentDiv.querySelector("p");
+    const colorCode = colorCodeP.textContent.trim();
+
+    // Remove the divs that contain the color code
+    // Since the specific structure is known, navigate up twice to remove the correct divs
+    colorCodeP.parentElement.parentElement.remove();
+    // Alternate way to remove divs starting from parent 'div' (less safe)
+    // parentDiv.firstElementChild.remove();
+
+    // Set the extracted color code as the background of the parent 'div'
+    parentDiv.style[
+        colorCode.charAt(0) === "#" ? "backgroundColor" : "background"
+    ] = colorCode;
 }
+
 function processHero(el) {
     processBackgroundColor(el);
     // add code here
@@ -70,7 +88,7 @@ function processFaq(el) {
 function processBanner(el) {
     // add code here
 }
-document.querySelectorAll('.hero').forEach(processHero);
-document.querySelectorAll('.brick').forEach(processBrick);
-document.querySelectorAll('.faq').forEach(processFaq);
-document.querySelectorAll('.banner').forEach(processBanner);
+document.querySelectorAll(".hero").forEach(processHero);
+document.querySelectorAll(".brick").forEach(processBrick);
+document.querySelectorAll(".faq").forEach(processFaq);
+document.querySelectorAll(".banner").forEach(processBanner);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,30 @@ const FAQ = [
 ];
 
 // add code here if needed
+function processLinks(parentDiv, parentTag, additionalClass = "") {
+    // Find all 'a' tags that are children of the specified parent tags
+    const allAsInsideParent = parentDiv.querySelectorAll(`${parentTag} > a`);
+
+    // Iterate over each found 'a' tag
+    allAsInsideParent.forEach(function (a) {
+        // Add the class "con-button" to the 'a' tag, and any additional class if provided
+        a.classList.add("con-button");
+        if (additionalClass) {
+            a.classList.add(additionalClass);
+        }
+
+        // Get the parent tag
+        const parentTag = a.parentNode;
+
+        // Use insertBefore to move the 'a' tag outside, just before the parent tag
+        parentTag.parentNode.insertBefore(a, parentTag);
+
+        // Delete the parent tag if it's empty now
+        if (!parentTag.hasChildNodes()) {
+            parentTag.parentNode.removeChild(parentTag);
+        }
+    });
+}
 
 function processBackgroundColor(el) {
     // add code here
@@ -39,7 +63,24 @@ function processBackgroundColor(el) {
 function processHero(el) {
     processBackgroundColor(el);
     // add code here
+    processLinks(el, "b");
+    processLinks(el, "i", "blue");
+
+    // Define parent 'div'
+    const parentDiv = el;
+
+    // Find all 'p' tags in the parent 'div'
+    const allPs = parentDiv.querySelectorAll("p");
+
+    // Iterate through each 'p' tag to find one that contains an 'a' tag
+    allPs.forEach(function (p) {
+        if (p.querySelector("a")) {
+            // If a 'p' tag contains an 'a' tag, add the 'action-area' class to the 'p' tag
+            p.classList.add("action-area");
+        }
+    });
 }
+
 function processBrick(el) {
     processBackgroundColor(el);
     // add code here

--- a/index.js
+++ b/index.js
@@ -103,45 +103,65 @@ function processBrick(el) {
 
 function processFaq(el) {
     // improve this code
-    el.innerHTML = `
+    // Initialize an empty string to hold the HTML
+    let htmlContent = "";
+
+    // Loop through each FAQ item in the array
+    for (let i = 0; i < FAQ.length; i++) {
+        // Append the FAQ set HTML to the htmlContent string
+        htmlContent += `
         <div class="faq-set">
-            <div class="question">
-                <div>
-                    <h3>${FAQ[0].q}</h3>
-                </div>
+          <div class="question">
+            <div>
+              <h3>${FAQ[i].q}</h3>
             </div>
-            <div class="answer">
-                <div>
-                    <p>${FAQ[0].a}</p>
-                </div>
+          </div>
+          <div class="answer">
+            <div>
+              <p>${FAQ[i].a}</p>
             </div>
-        </div>
-        <div class="faq-set">
-            <div class="question">
-                <div>
-                    <h3>${FAQ[1].q}</h3>
-                </div>
-            </div>
-            <div class="answer">
-                <div>
-                    <p>${FAQ[1].a}</p>
-                </div>
-            </div>
-        </div>
-        <div class="faq-set">
-            <div class="question">
-                <div>
-                    <h3>${FAQ[2].q}</h3>
-                </div>
-            </div>
-            <div class="answer">
-                <div>
-                    <p>${FAQ[2].a}</p>
-                </div>
-            </div>
+          </div>
         </div>`;
+    }
+
+    // Set the innerHTML of the element to the generated HTML content
+    el.innerHTML = htmlContent;
+
     // add code here
+    // Define parent 'div'
+    const parentDiv = el;
+
+    // Add click event listeners to each FAQ set after rendering
+    parentDiv.querySelectorAll(".faq-set").forEach((faqSet) => {
+        faqSet.addEventListener("click", function () {
+            const question = this.querySelector(".question");
+            const answer = this.querySelector(".answer");
+            const isAlreadyOpen = answer.classList.contains("open");
+
+            // Close all open answers and rotate chevrons back
+            parentDiv
+                .querySelectorAll(".faq .answer.open")
+                .forEach((openAnswer) => {
+                    openAnswer.classList.remove("open");
+                    openAnswer.previousElementSibling.classList.remove(
+                        "rotated"
+                    );
+                    openAnswer.style.maxHeight = null;
+                });
+
+            // If the clicked FAQ was not already open, open it and rotate the chevron
+            if (!isAlreadyOpen) {
+                answer.classList.add("open");
+                question.classList.add("rotated"); // Add rotated class to the question
+                answer.style.maxHeight = answer.scrollHeight + "px";
+            } else {
+                // If it was open, we're closing it, so remove the rotated class
+                question.classList.remove("rotated");
+            }
+        });
+    });
 }
+
 function processBanner(el) {
     // add code here
 }


### PR DESCRIPTION
Following are screenshots in the step-by-step updates after each commit for each function and miscellaneous changes that were made.

_Note: Added meta tag for viewport so that I can see my responsive changes in the emulators in chrome/edge browsers while developing._

Default:
![image](https://github.com/vuice/interview-test/assets/1916269/3a06d4f0-6d9f-4042-903c-2cf3ce45eb1b)

Updates to processBackgroundColor():
![image](https://github.com/vuice/interview-test/assets/1916269/f36a5ece-2682-4451-b1e6-8ae3924ad2f7)

Updates to processHero():
![image](https://github.com/vuice/interview-test/assets/1916269/070e5250-6242-40df-9344-78669603bcb6)

Updates to processBrick():
![image](https://github.com/vuice/interview-test/assets/1916269/a091f03e-df80-45f4-af34-21d3b083726b)

Updates to processFaq():
![image](https://github.com/vuice/interview-test/assets/1916269/d1a7697f-ecc2-401f-9701-73a70c695181)
![image](https://github.com/vuice/interview-test/assets/1916269/9caf60a8-7874-411d-b501-2e4e2e841c56)

Updates to processBanner():
![image](https://github.com/vuice/interview-test/assets/1916269/61bb5b60-19c8-4d69-b33c-056bb6bdd8a1)

Updates to masonry section:
![image](https://github.com/vuice/interview-test/assets/1916269/86d9c793-6810-480b-a0b4-ce3e5405280e)

Updates to media queries & added meta for viewport:
_For tablet sizes, stacked the bricks on top of each other_
![image](https://github.com/vuice/interview-test/assets/1916269/ce8b927f-55ec-454d-96bf-cd0c07ca1c69)

_For mobile sizes, stacked the bricks on top of each other & made CTA buttons almost as wide as the screen_
![image](https://github.com/vuice/interview-test/assets/1916269/e137ef8f-d9cd-495a-8416-7d58722d0730)
